### PR TITLE
Restore corner ribbon visibility

### DIFF
--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -135,7 +135,7 @@ For inquiries or permissions, contact daniel@section.store
     margin-left: {{ margin_horizontal_mobile }}rem;
     margin-right: {{ margin_horizontal_mobile }}rem;
     border-radius: {{ section_radius | times: 0.6 | round: 0 }}px;
-    overflow: hidden;
+    overflow: visible;
   }
   
   .section-{{ section.id }}-settings {

--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -780,9 +780,9 @@ For inquiries or permissions, contact daniel@section.store
    tunable via CSS custom properties so it still reads as a wrap while staying
    inside an overflow:hidden container */
 .corner-ribbon.corner-ribbon--tr{
-  --ribbon-width: 12.5rem;
-  --ribbon-offset: 2.5rem;
-  --ribbon-top: 1.75rem;
+  --ribbon-width: 13.75rem;
+  --ribbon-offset: 1.75rem;
+  --ribbon-top: 2.4rem;
   position: absolute;
   z-index: 9;
   top: var(--ribbon-top);
@@ -866,9 +866,9 @@ For inquiries or permissions, contact daniel@section.store
 /* responsive tweak */
 @media (max-width: 767px){
   .corner-ribbon.corner-ribbon--tr{
-    --ribbon-width: 10.5rem;
-    --ribbon-offset: 1.9rem;
-    --ribbon-top: 1.35rem;
+    --ribbon-width: 11.5rem;
+    --ribbon-offset: 1.35rem;
+    --ribbon-top: 1.85rem;
   }
   .corner-ribbon__text{ font-size: 11px; padding: 8px 0; }
 }

--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -780,9 +780,9 @@ For inquiries or permissions, contact daniel@section.store
    tunable via CSS custom properties so it still reads as a wrap while staying
    inside an overflow:hidden container */
 .corner-ribbon.corner-ribbon--tr{
-  --ribbon-width: 16.25rem;
-  --ribbon-offset: 1rem;
-  --ribbon-top: 2.85rem;
+  --ribbon-width: 21rem;
+  --ribbon-offset: 1.6rem;
+  --ribbon-top: 3.35rem;
   position: absolute;
   z-index: 9;
   top: var(--ribbon-top);
@@ -866,9 +866,9 @@ For inquiries or permissions, contact daniel@section.store
 /* responsive tweak */
 @media (max-width: 767px){
   .corner-ribbon.corner-ribbon--tr{
-    --ribbon-width: 13.5rem;
-    --ribbon-offset: 0.8rem;
-    --ribbon-top: 2.2rem;
+    --ribbon-width: 17rem;
+    --ribbon-offset: 1.15rem;
+    --ribbon-top: 2.6rem;
   }
   .corner-ribbon__text{ font-size: 11px; padding: 8px 0; }
 }

--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -135,7 +135,7 @@ For inquiries or permissions, contact daniel@section.store
     margin-left: {{ margin_horizontal_mobile }}rem;
     margin-right: {{ margin_horizontal_mobile }}rem;
     border-radius: {{ section_radius | times: 0.6 | round: 0 }}px;
-    overflow: visible;
+    overflow: hidden;
   }
   
   .section-{{ section.id }}-settings {
@@ -777,15 +777,19 @@ For inquiries or permissions, contact daniel@section.store
 .collection-media-{{ section.id }} { position: relative; }
 
 /* the wrapper sits a little down from the top and a little past the right edge,
-   then rotates to cut diagonally across the corner */
+   tunable via CSS custom properties so it still reads as a wrap while staying
+   inside an overflow:hidden container */
 .corner-ribbon.corner-ribbon--tr{
+  --ribbon-width: 13.75rem;
+  --ribbon-offset: 3.75rem;
+  --ribbon-top: 1.25rem;
   position: absolute;
   z-index: 9;
-  top: 14px;                 /* adjust: 10–18px depending on taste */
-  right: -58px;              /* pulls it past the right edge so the diagonal shows */
-  width: 230px;              /* band length across the corner */
+  top: var(--ribbon-top);
+  right: calc(var(--ribbon-offset) * -1);
+  width: var(--ribbon-width);
   transform: rotate(45deg);
-  transform-origin: center;
+  transform-origin: 100% 0;
   pointer-events: none;      /* won’t block clicks on the product */
 }
 
@@ -861,7 +865,11 @@ For inquiries or permissions, contact daniel@section.store
 
 /* responsive tweak */
 @media (max-width: 767px){
-  .corner-ribbon.corner-ribbon--tr{ width: 190px; right: -48px; top: 10px; }
+  .corner-ribbon.corner-ribbon--tr{
+    --ribbon-width: 11.5rem;
+    --ribbon-offset: 3.25rem;
+    --ribbon-top: 0.75rem;
+  }
   .corner-ribbon__text{ font-size: 11px; padding: 8px 0; }
 }
 

--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -780,9 +780,9 @@ For inquiries or permissions, contact daniel@section.store
    tunable via CSS custom properties so it still reads as a wrap while staying
    inside an overflow:hidden container */
 .corner-ribbon.corner-ribbon--tr{
-  --ribbon-width: 13.75rem;
-  --ribbon-offset: 1.75rem;
-  --ribbon-top: 2.4rem;
+  --ribbon-width: 16.25rem;
+  --ribbon-offset: 1rem;
+  --ribbon-top: 2.85rem;
   position: absolute;
   z-index: 9;
   top: var(--ribbon-top);
@@ -866,9 +866,9 @@ For inquiries or permissions, contact daniel@section.store
 /* responsive tweak */
 @media (max-width: 767px){
   .corner-ribbon.corner-ribbon--tr{
-    --ribbon-width: 11.5rem;
-    --ribbon-offset: 1.35rem;
-    --ribbon-top: 1.85rem;
+    --ribbon-width: 13.5rem;
+    --ribbon-offset: 0.8rem;
+    --ribbon-top: 2.2rem;
   }
   .corner-ribbon__text{ font-size: 11px; padding: 8px 0; }
 }

--- a/ss-collection-13.liquid
+++ b/ss-collection-13.liquid
@@ -181,7 +181,7 @@ For inquiries or permissions, contact daniel@section.store
   
   .collection-media-{{ section.id }} {
     position: relative;
-    overflow: visible;
+    overflow: hidden;
     border: {{ media_border_thickness }}px solid {{ media_border_color }};
     border-radius: {{ media_radius }}px;
     display: block;
@@ -780,9 +780,9 @@ For inquiries or permissions, contact daniel@section.store
    tunable via CSS custom properties so it still reads as a wrap while staying
    inside an overflow:hidden container */
 .corner-ribbon.corner-ribbon--tr{
-  --ribbon-width: 13.75rem;
-  --ribbon-offset: 3.75rem;
-  --ribbon-top: 1.25rem;
+  --ribbon-width: 12.5rem;
+  --ribbon-offset: 2.5rem;
+  --ribbon-top: 1.75rem;
   position: absolute;
   z-index: 9;
   top: var(--ribbon-top);
@@ -866,9 +866,9 @@ For inquiries or permissions, contact daniel@section.store
 /* responsive tweak */
 @media (max-width: 767px){
   .corner-ribbon.corner-ribbon--tr{
-    --ribbon-width: 11.5rem;
-    --ribbon-offset: 3.25rem;
-    --ribbon-top: 0.75rem;
+    --ribbon-width: 10.5rem;
+    --ribbon-offset: 1.9rem;
+    --ribbon-top: 1.35rem;
   }
   .corner-ribbon__text{ font-size: 11px; padding: 8px 0; }
 }


### PR DESCRIPTION
## Summary
- allow the section container to overflow visibly so the corner ribbon is no longer clipped

## Testing
- not run (liquid-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dc8871a3b08331ba102b73039d0f16